### PR TITLE
Rename :line to :line_number so as not to over-write the :line method

### DIFF
--- a/lib/code_analyzer/sexp.rb
+++ b/lib/code_analyzer/sexp.rb
@@ -13,22 +13,22 @@ class Sexp
   #
   #     s(:@ident, "test", s(2, 12)
   #       => 2
-  def line
+  def line_number
     case sexp_type
     when :def, :defs, :command, :command_call, :call, :fcall, :method_add_arg, :method_add_block,
          :var_ref, :vcall, :const_ref, :const_path_ref, :class, :module,
          :if, :unless, :elsif, :ifop, :if_mod, :unless_mod, :binary,
          :alias, :symbol_literal, :symbol, :aref, :hash, :assoc_new, :string_literal,
          :massign
-      self[1].line
+      self[1].line_number
     when :assoclist_from_args, :bare_assoc_hash
-      self[1][0].line
+      self[1][0].line_number
     when :string_add, :opassign
-      self[2].line
+      self[2].line_number
     when :array
-      array_values.first.line
+      array_values.first.line_number
     when :mlhs_add
-      self.last.line
+      self.last.line_number
     else
       self.last.first if self.last.is_a? Array
     end

--- a/spec/code_analyzer/sexp_spec.rb
+++ b/spec/code_analyzer/sexp_spec.rb
@@ -28,47 +28,47 @@ describe Sexp do
     end
 
     it "should return class line" do
-      @node.grep_node(sexp_type: :class).line.should == 1
+      @node.grep_node(sexp_type: :class).line_number.should == 1
     end
 
     it "should return def line" do
-      @node.grep_node(sexp_type: :def).line.should == 2
+      @node.grep_node(sexp_type: :def).line_number.should == 2
     end
 
     it "should return const line" do
-      @node.grep_node(sexp_type: :const_ref).line.should == 1
+      @node.grep_node(sexp_type: :const_ref).line_number.should == 1
     end
 
     it "should return const path line" do
-      @node.grep_node(sexp_type: :const_path_ref).line.should == 3
+      @node.grep_node(sexp_type: :const_path_ref).line_number.should == 3
     end
 
     it "should return alias line" do
-      @node.grep_node(sexp_type: :alias).line.should == 5
+      @node.grep_node(sexp_type: :alias).line_number.should == 5
     end
 
     it "should return hash line" do
-      @node.grep_node(sexp_type: :hash).line.should == 6
+      @node.grep_node(sexp_type: :hash).line_number.should == 6
     end
 
     it "should return massign line" do
-      @node.grep_node(sexp_type: :massign).line.should == 8
+      @node.grep_node(sexp_type: :massign).line_number.should == 8
     end
 
     it "should return opassign line" do
-      @node.grep_node(sexp_type: :opassign).line.should == 11
+      @node.grep_node(sexp_type: :opassign).line_number.should == 11
     end
 
     it "should return if line" do
-      expect(@node.grep_node(sexp_type: :if).line).to eq 14
+      expect(@node.grep_node(sexp_type: :if).line_number).to eq 14
     end
 
     it "should return elsif line" do
-      expect(@node.grep_node(sexp_type: :elsif).line).to eq 16
+      expect(@node.grep_node(sexp_type: :elsif).line_number).to eq 16
     end
 
     it "should return if_mod line" do
-      expect(@node.grep_node(sexp_type: :if_mod).line).to eq 15
+      expect(@node.grep_node(sexp_type: :if_mod).line_number).to eq 15
     end
   end
 


### PR DESCRIPTION
Over-writing :line breaks ruby_parser or any other libraries that
do not expect the monkey-patch

Is used with https://github.com/railsbp/rails_best_practices/pull/173
