### PR TITLE
Rename Sexp#block to Sexp#block_type for RubyParser compatibility

### DIFF
--- a/lib/code_analyzer/sexp.rb
+++ b/lib/code_analyzer/sexp.rb
@@ -465,7 +465,7 @@ class Sexp
   #            )
   #
   # @return [Sexp] body node
-  def block
+  def block_type
     case sexp_type
     when :method_add_block
       self[2]
@@ -872,7 +872,7 @@ class Sexp
 
   # if the return value of these methods is nil, then return CodeAnalyzer::Nil.new instead
   [:sexp_type, :receiver, :message, :arguments, :argument, :class_name, :base_class, :method_name,
-   :body, :block, :conditional_statement, :left_value, :right_value].each do |method|
+   :body, :block_type, :conditional_statement, :left_value, :right_value].each do |method|
     class_eval <<-EOS
       alias_method :origin_#{method}, :#{method}
 

--- a/spec/code_analyzer/sexp_spec.rb
+++ b/spec/code_analyzer/sexp_spec.rb
@@ -439,7 +439,7 @@ describe Sexp do
   describe "block" do
     it "sould get block of method_add_block node" do
       node = parse_content("resources :posts do; resources :comments; end").grep_node(sexp_type: :method_add_block)
-      node.block.sexp_type.should == :do_block
+      node.block_type.sexp_type.should == :do_block
     end
   end
 


### PR DESCRIPTION
Another RubyParser compatibility bug.  I should try running the ruby_parser test suite with code_analyzer required.

This bug kills Flog https://github.com/metricfu/metric_fu/issues/123
