### PR TITLE
Update RSpec version to 3

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format nested
+--format documentation
 --color

--- a/spec/code_analyzer/checker_spec.rb
+++ b/spec/code_analyzer/checker_spec.rb
@@ -29,12 +29,12 @@ module CodeAnalyzer
     context "#parse_file?" do
       it "should return true if node_file matches pattern" do
         allow(checker).to receive(:interesting_files).and_return([/spec\/.*\.rb/, /lib\/.*\.rb/])
-        expect(checker.parse_file?("lib/code_analyzer.rb")).to be_true
+        expect(checker.parse_file?("lib/code_analyzer.rb")).to be true
       end
 
       it "should return false if node_file doesn't match pattern" do
         allow(checker).to receive(:interesting_files).and_return([/spec\/.*\.rb/])
-        expect(checker.parse_file?("lib/code_analyzer.rb")).to be_false
+        expect(checker.parse_file?("lib/code_analyzer.rb")).to be false
       end
     end
 

--- a/spec/code_analyzer/checking_visitor/plain_spec.rb
+++ b/spec/code_analyzer/checking_visitor/plain_spec.rb
@@ -11,7 +11,7 @@ module CodeAnalyzer::CheckingVisitor
       content = "content"
       expect(checker1).to receive(:parse_file?).and_return(false)
       expect(checker2).to receive(:parse_file?).and_return(true)
-      checker1.should_not_receive(:check).with(filename, content)
+      expect(checker1).not_to receive(:check).with(filename, content)
       expect(checker2).to receive(:check).with(filename, content)
 
       visitor.check(filename, content)


### PR DESCRIPTION
Problems
--------

### 1. formatter

```
$ bundle exec rake spec
/usr/bin/ruby -I/home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib:/home/pocke/.gem/ruby/2.3.0/gems/rspec-support-3.5.0/lib /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --color
/home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/formatters.rb:173:in `find_formatter': Formatter 'nested' unknown - maybe you meant 'documentation' or 'progress'?. (ArgumentError)
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/formatters.rb:141:in `add'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/configuration.rb:828:in `add_formatter'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/configuration_options.rb:117:in `block in load_formatters_into'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/configuration_options.rb:117:in `each'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/configuration_options.rb:117:in `load_formatters_into'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/configuration_options.rb:23:in `configure'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/runner.rb:99:in `setup'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/runner.rb:86:in `run'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/runner.rb:71:in `run'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/runner.rb:45:in `invoke'
	from /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/exe/rspec:4:in `<main>'
/usr/bin/ruby -I/home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/lib:/home/pocke/.gem/ruby/2.3.0/gems/rspec-support-3.5.0/lib /home/pocke/.gem/ruby/2.3.0/gems/rspec-core-3.5.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --color failed
```


In RSpec 3, `nested` is not supported as a formatter.
(See. http://stackoverflow.com/questions/24688592/rspec-cant-find-nested-formatter )

So, it uses documentation instead of nested as a formatter.

### 2. be_true / be_false

```
Failures:

  1) CodeAnalyzer::Checker#parse_file? should return true if node_file matches pattern
     Failure/Error: expect(checker.parse_file?("lib/code_analyzer.rb")).to be_true
       expected true to respond to `true?` or perhaps you meant `be true` or `be_truthy`
     # ./spec/code_analyzer/checker_spec.rb:32:in `block (3 levels) in <module:CodeAnalyzer>'

  2) CodeAnalyzer::Checker#parse_file? should return false if node_file doesn't match pattern
     Failure/Error: expect(checker.parse_file?("lib/code_analyzer.rb")).to be_false
       expected false to respond to `false?` or perhaps you meant `be false` or `be_falsey`
     # ./spec/code_analyzer/checker_spec.rb:37:in `block (3 levels) in <module:CodeAnalyzer>'
```

In RSpec 3, be_true and be_false are deleted.
So, it uses `be true` and `be false` instead of the above.


### 3. should_not_receive

In RSpec 3, `should_not-receive` is deprecated.
So, it uses `expect(...).not_to receive` instead of the above.