### PR TITLE
Call check_node directly to avoid stack over flow

### DIFF
--- a/lib/code_analyzer/checking_visitor/default.rb
+++ b/lib/code_analyzer/checking_visitor/default.rb
@@ -56,7 +56,7 @@ module CodeAnalyzer::CheckingVisitor
       end
       node.children.each { |child_node|
         child_node.file = node.file
-        child_node.check(self)
+        check_node(child_node)
       }
       if checkers
         checkers.each { |checker| checker.node_end(node) if checker.parse_file?(node.file) }


### PR DESCRIPTION
Rails best practices crashes stack over flow when it analyses a very large array literal. 

For example.

`test.rb` is at  https://gist.github.com/pocke/baa2aeef6e5c3281542ad6c6e091cb6c

```
$ rails_best_practices test.rb
Source Code: |/home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/sexp.rb:41:in `block in children': stack level too deep (SystemStackError)
	from /home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/sexp.rb:41:in `each'
	from /home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/sexp.rb:41:in `find_all'
	from /home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/sexp.rb:41:in `children'
	from /home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/checking_visitor/default.rb:57:in `check_node'
	from /home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/sexp.rb:9:in `check'
	from /home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/checking_visitor/default.rb:59:in `block in check_node'
	from /home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/checking_visitor/default.rb:57:in `each'
	from /home/pocke/.gem/ruby/2.3.0/gems/code_analyzer-0.4.5/lib/code_analyzer/checking_visitor/default.rb:57:in `check_node'
	 ... 11139 levels...
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /home/pocke/.gem/ruby/2.3.0/gems/rails_best_practices-1.17.0/bin/rails_best_practices:6:in `<top (required)>'
	from /home/pocke/.gem/ruby/2.3.0/bin//rails_best_practices:23:in `load'
	from /home/pocke/.gem/ruby/2.3.0/bin//rails_best_practices:23:in `<main>'
```

The PR reduces calling method to avoid stack over flow.



Maybe the PR resolves #5 


### Environment

```
$ ruby -v 
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]

$ rails_best_practices -v
1.17.0
```