### PR TITLE
return empty array in %w(), %W(), %i()

### DIFF
--- a/lib/code_analyzer/sexp.rb
+++ b/lib/code_analyzer/sexp.rb
@@ -737,7 +737,7 @@ class Sexp
   def array_values
     case sexp_type
     when :array
-      if nil == self[1]
+      if nil == self[1] || [:words_new, :qwords_new, :qsymbols_new].include?(self[1].sexp_type)
         []
       elsif [:words_add, :qwords_add, :qsymbols_add].include? self[1].sexp_type
         self[1].array_values

--- a/spec/code_analyzer/sexp_spec.rb
+++ b/spec/code_analyzer/sexp_spec.rb
@@ -563,15 +563,30 @@ describe Sexp do
       expect(node.array_values.map(&:to_s)).to eq ["day", "week", "fortnight"]
     end
 
+    it "should get empty array values with array and words_add" do
+      node = parse_content("%W{}").grep_node(sexp_type: :array)
+      expect(node.array_values.map(&:to_s)).to eq []
+    end
+
     it "should get array value with array and qwords_add" do
       node = parse_content("%w(first_name last_name)").grep_node(sexp_type: :array)
       expect(node.array_values.map(&:to_s)).to eq ["first_name", "last_name"]
+    end
+
+    it "should get empty array values with array and qwords_add" do
+      node = parse_content("%w()").grep_node(sexp_type: :array)
+      expect(node.array_values.map(&:to_s)).to eq []
     end
 
     if RUBY_VERSION.to_i > 1
       it "should get array value with array and qsymbols_add" do
         node = parse_content("%i(first_name last_name)").grep_node(sexp_type: :array)
         expect(node.array_values.map(&:to_s)).to eq ["first_name", "last_name"]
+      end
+
+      it "should get empty array values with array and qsymbols_new" do
+        node = parse_content("%i()").grep_node(sexp_type: :array)
+        expect(node.array_values.map(&:to_s)).to eq []
       end
     end
   end


### PR DESCRIPTION
Rails best practices freezes when analyze this example code:

```
resources :sites, only: %i()
```

The following results:

```
$ rails_best_practices test.rb
^C/usr/local/bundle/gems/sexp_processor-4.7.0/lib/sexp.rb:234:in `sexp_type': Interrupt                                                                                                                                                                                                                                                                                    |
        from (eval):4:in `sexp_type'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/sexp.rb:308:in `all'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/sexp.rb:745:in `array_values'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/core/check.rb:289:in `mark_used'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/core/check.rb:243:in `block (3 levels) in included'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/core/check.rb:243:in `each'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/core/check.rb:243:in `block (2 levels) in included'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checker.rb:32:in `instance_exec'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checker.rb:32:in `block in node_start'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checker.rb:31:in `each'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checker.rb:31:in `node_start'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:55:in `block in check_node'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:55:in `each'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:55:in `check_node'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:59:in `block in check_node'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:57:in `each'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:57:in `check_node'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:59:in `block in check_node'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:57:in `each'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:57:in `check_node'
        from /usr/local/bundle/gems/code_analyzer-0.4.6/lib/code_analyzer/checking_visitor/default.rb:24:in `check'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/core/runner.rb:91:in `review'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/analyzer.rb:89:in `block in process'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/analyzer.rb:86:in `each'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/analyzer.rb:86:in `process'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/analyzer.rb:316:in `block in analyze_source_codes'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/analyzer.rb:316:in `each'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/analyzer.rb:316:in `analyze_source_codes'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/analyzer.rb:55:in `analyze'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/lib/rails_best_practices/command.rb:136:in `<top (required)>'
        from /usr/local/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/bundle/gems/rails_best_practices-1.17.0/bin/rails_best_practices:6:in `<top (required)>'
        from /usr/local/bundle/bin/rails_best_practices:23:in `load'
        from /usr/local/bundle/bin/rails_best_practices:23:in `<main>'
```

According to my understanding, it happen in call `array_values` method for empty array by percent strings. In this case, `sexp_type` are `:words_new`, `:qwords_new` and `qsymbols_new`.
This PR make it to return empty array if declare empty array by percent strings.

### Environment

```
$ ruby -v
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-linux]

$ rails_best_practices -v
1.17.0

$ gem list | grep code_analyzer
code_analyzer (0.4.6)
```