### PR TITLE
Auto corrected by following Lint Ruby Style/Encoding

### DIFF
--- a/code_analyzer.gemspec
+++ b/code_analyzer.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 
 require File.expand_path('../lib/code_analyzer/version', __FILE__)

--- a/lib/code_analyzer.rb
+++ b/lib/code_analyzer.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'ripper'

--- a/lib/code_analyzer/analyzer_exception.rb
+++ b/lib/code_analyzer/analyzer_exception.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer

--- a/lib/code_analyzer/checker.rb
+++ b/lib/code_analyzer/checker.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer

--- a/lib/code_analyzer/checking_visitor.rb
+++ b/lib/code_analyzer/checking_visitor.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer

--- a/lib/code_analyzer/checking_visitor/base.rb
+++ b/lib/code_analyzer/checking_visitor/base.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer::CheckingVisitor

--- a/lib/code_analyzer/checking_visitor/default.rb
+++ b/lib/code_analyzer/checking_visitor/default.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer::CheckingVisitor

--- a/lib/code_analyzer/checking_visitor/plain.rb
+++ b/lib/code_analyzer/checking_visitor/plain.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer::CheckingVisitor

--- a/lib/code_analyzer/nil.rb
+++ b/lib/code_analyzer/nil.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer

--- a/lib/code_analyzer/sexp.rb
+++ b/lib/code_analyzer/sexp.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'sexp'

--- a/lib/code_analyzer/version.rb
+++ b/lib/code_analyzer/version.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer

--- a/lib/code_analyzer/warning.rb
+++ b/lib/code_analyzer/warning.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module CodeAnalyzer


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/Encoding

Click [here](https://awesomecode.io/repos/flyerhzm/code_analyzer/lint_configs/ruby/16263) to configure it on awesomecode.io