### PR TITLE
Fix `Sexp#line_number` on various types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.4
+  - 2.6.6
+  - 2.7.1

--- a/lib/code_analyzer/sexp.rb
+++ b/lib/code_analyzer/sexp.rb
@@ -20,16 +20,18 @@ class Sexp
     case sexp_type
     when :def, :defs, :command, :command_call, :call, :fcall, :method_add_arg, :method_add_block, :var_ref, :vcall,
          :const_ref, :const_path_ref, :class, :module, :if, :unless, :elsif, :ifop, :if_mod, :unless_mod, :binary, :alias,
-         :symbol_literal, :symbol, :aref, :hash, :assoc_new, :string_literal, :massign, :var_field
+         :symbol_literal, :symbol, :aref, :hash, :assoc_new, :string_literal, :massign, :var_field, :assign, :paren
       self[1].line_number
     when :assoclist_from_args, :bare_assoc_hash
       self[1][0].line_number
-    when :string_add, :opassign, :unary
+    when :string_add, :opassign, :unary, :stmts_add
       self[2].line_number
     when :array
       array_values.first.line_number
     when :mlhs_add
       self.last.line_number
+    when :params
+      self[1][0].line_number if self[1].is_a? Array
     else
       self.last.first if self.last.is_a? Array
     end

--- a/spec/code_analyzer/sexp_spec.rb
+++ b/spec/code_analyzer/sexp_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Sexp do
-  describe 'line' do
+  describe 'line_number' do
     before :each do
       content = <<-EOF
       class Demo
@@ -75,6 +75,67 @@ describe Sexp do
 
     it 'should return unary line' do
       expect(@node.grep_node(sexp_type: :unary).line_number).to eq 15
+    end
+
+    it 'should return assign line' do
+      expect(@node.grep_node(sexp_type: :assign).line_number).to eq 6
+    end
+
+    it 'should return paren line' do
+      expect(@node.grep_node(sexp_type: :paren).line_number).to eq 10
+    end
+
+    it 'should return params line' do
+      expect(@node.grep_node(sexp_type: :params).line_number).to be_nil
+    end
+
+    it 'should return params line if not empty' do
+      @node = parse_content(<<~CODE)
+        # @see Foo
+        def foo(a, b)
+        end
+      CODE
+      expect(@node.grep_node(sexp_type: :params).line_number).to eq 2
+    end
+
+    it 'should return stmts_add line' do
+      expect(@node.grep_node(sexp_type: :stmts_add).line_number).to eq 13
+    end
+
+    context 'when a complex code is given' do
+      before :each do
+        @node = parse_content(<<~CODE)
+          def foo(num)
+            unless (num == 0 ? :zero, :other) || !@opts.right?
+              @bar = {}
+            end
+          end
+        CODE
+      end
+
+      it 'should return unless line' do
+        expect(@node.grep_node(sexp_type: :unless).line_number).to eq 2
+      end
+
+      it 'should return paren line' do
+        expect(@node.grep_node(sexp_type: :paren).line_number).to eq 1
+      end
+
+      it 'should return stmts_add line' do
+        expect(@node.grep_node(sexp_type: :stmts_add).line_number).to eq 2
+      end
+
+      it 'should return binary line' do
+        expect(@node.grep_node(sexp_type: :binary).line_number).to eq 2
+      end
+
+      it 'should return unary line' do
+        expect(@node.grep_node(sexp_type: :unary).line_number).to eq 2
+      end
+
+      it 'should return assign line' do
+        expect(@node.grep_node(sexp_type: :assign).line_number).to eq 3
+      end
     end
   end
 


### PR DESCRIPTION
This PR aims to fix the `Sexp#line_number` method on the following `sexp_type` (related to PR #13).

- `:assign`
- `:paren`
- `:stmts_add`
- `:params`
