### PR TITLE
Fix `Sexp#line_number` on `:top_const_ref`, `:dot2`, and `:dot3` types

### DIFF
--- a/lib/code_analyzer/sexp.rb
+++ b/lib/code_analyzer/sexp.rb
@@ -19,8 +19,8 @@ class Sexp
   def line_number
     case sexp_type
     when :def, :defs, :command, :command_call, :call, :fcall, :method_add_arg, :method_add_block, :var_ref, :vcall,
-         :const_ref, :const_path_ref, :class, :module, :if, :unless, :elsif, :ifop, :if_mod, :unless_mod, :binary, :alias,
-         :symbol_literal, :symbol, :aref, :hash, :assoc_new, :string_literal, :massign, :var_field, :assign, :paren
+         :const_ref, :top_const_ref, :const_path_ref, :class, :module, :if, :unless, :elsif, :ifop, :if_mod, :unless_mod, :binary, :alias,
+         :symbol_literal, :symbol, :aref, :hash, :assoc_new, :string_literal, :massign, :var_field, :assign, :paren, :dot2, :dot3
       self[1].line_number
     when :assoclist_from_args, :bare_assoc_hash
       self[1][0].line_number

--- a/spec/code_analyzer/sexp_spec.rb
+++ b/spec/code_analyzer/sexp_spec.rb
@@ -22,7 +22,10 @@ describe Sexp do
           if success?
             puts "unknown" if !output?
           elsif fail?
+            1..2
+            3...4
           end
+          pp ::Rails.application
         end
       end
       EOF
@@ -39,6 +42,10 @@ describe Sexp do
 
     it 'should return const line' do
       expect(@node.grep_node(sexp_type: :const_ref).line_number).to eq 1
+    end
+
+    it 'should return top const line' do
+      expect(@node.grep_node(sexp_type: :top_const_ref).line_number).to eq 20
     end
 
     it 'should return const path line' do
@@ -83,6 +90,14 @@ describe Sexp do
 
     it 'should return paren line' do
       expect(@node.grep_node(sexp_type: :paren).line_number).to eq 10
+    end
+
+    it 'should return dot2 line' do
+      expect(@node.grep_node(sexp_type: :dot2).line_number).to eq 17
+    end
+
+    it 'should return dot3 line' do
+      expect(@node.grep_node(sexp_type: :dot3).line_number).to eq 18
     end
 
     it 'should return params line' do


### PR DESCRIPTION
This PR aims to fix the `Sexp#line_number` method on the following `sexp_type`:

- `:top_const_ref`
- `:dot2`
- `:dot3`

Related to #13 #30